### PR TITLE
Remove "--save" from the Installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 ## Installation
 
 1. Download from npm:  
-`npm install ngx-overflow-shadow --save`
+`npm install ngx-overflow-shadow`
 
 2. Import the `NgxOverflowShadowModule` module:    
 `import {NgxOverflowShadowModule} from 'ngx-overflow-shadow'`


### PR DESCRIPTION
["As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."](https://stackoverflow.com/questions/19578796/what-is-the-save-option-for-npm-install)